### PR TITLE
Perl 5.26.0 compatibility

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 
+use lib '.';
 use inc::Module::Install;
 
 name				'DateTime-Format-W3CDTF';


### PR DESCRIPTION
In Perl 5.26.0, '.' will no longer be found by default in @INC.  This patch
modifies Makefile.PL accordingly.