### PR TITLE
Add "strict" option to require timezone in time components

### DIFF
--- a/lib/DateTime/Format/W3CDTF.pm
+++ b/lib/DateTime/Format/W3CDTF.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use vars qw ($VERSION);
 
-$VERSION = '0.06';
+$VERSION = '0.07';
 
 use DateTime;
 use DateTime::TimeZone;
@@ -13,11 +13,14 @@ use DateTime::TimeZone;
 sub new {
     my $class = shift;
 
-    return bless {}, $class;
+    return bless {@_}, $class;
 }
 
 sub parse_datetime {
     my ( $self, $date ) = @_;
+
+    # Dummy self if called as class method.
+    $self = {} unless ref $self;
 
     my @fields = qw/ year month day hour minute second fraction time_zone /;
     my @values = 
@@ -41,6 +44,9 @@ sub parse_datetime {
        $p{$fields[$i]} = $values[$i];
     }
     
+    die "Invalid W3CDTF datetime string without timezone ($date)"
+        if $self->{strict} && $p{hour} && !$p{time_zone};
+
 ### support for YYYY-MM-DDT24:00:00 as a syntactic form for 00:00:00 on the day following YYYY-MM-DD
 ### this is allowed in xsd dateTime syntactic forms, but not W3CDTF.
 #     my $next_day    = 0;
@@ -76,6 +82,9 @@ sub parse_datetime {
 sub format_datetime {
     my ( $self, $dt ) = @_;
 
+    # Dummy self if called as class method.
+    $self = {} unless ref $self;
+
     my $base = sprintf(
         '%04d-%02d-%02dT%02d:%02d:%02d',
         $dt->year, $dt->month,  $dt->day,
@@ -90,15 +99,17 @@ sub format_datetime {
 
     my $tz = $dt->time_zone;
 
-    return $base if $tz->is_floating;
-
     return $base . 'Z' if $tz->is_utc;
 
-    my $offset = $dt->offset();
+    my $offset = $dt->offset;
 
-    return $base unless defined $offset;
+    if ($tz->is_floating or !defined $offset) {
+        die qq[Strict W3CDTF format does not support "floating" timezones]
+            if $self->{strict};
+        return $base;
+    }
 
-    return $base . _offset_as_string($offset)
+    return $base . _offset_as_string($offset);
 }
 
 sub format_date {
@@ -143,7 +154,7 @@ DateTime::Format::W3CDTF - Parse and format W3CDTF datetime strings
 
   use DateTime::Format::W3CDTF;
 
-  my $w3c = DateTime::Format::W3CDTF->new;
+  my $w3c = DateTime::Format::W3CDTF->new(strict => 1);
   my $dt = $w3c->parse_datetime( '2003-02-15T13:50:05-05:00' );
 
   # 2003-02-15T13:50:05-05:00
@@ -166,7 +177,15 @@ This API is currently experimental and may change in the future.
 
 =item * new()
 
-Returns a new W3CDTF parser object.
+Returns a new W3CDTF parser object.  Accepts a single C<strict> option:
+
+  DateTime::Format::W3CDTF->new(strict => 1);
+
+If true, parse_datetime() and format_datetime() will only accept and
+return strings in W3CDTF format, respectively.  In particular, the
+W3CDTF format requires all time components to have timezones.
+
+If false, timezones are optional.
 
 =item * parse_datetime($string)
 

--- a/t/01parse.t
+++ b/t/01parse.t
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-use Test::More tests => 18;
+use Test::More tests => 35;
 use strict;
 use vars qw( $class );
 
@@ -8,23 +8,37 @@ BEGIN {
     use_ok $class;
 }
 
-my @tests = (
-    '2003-02-10T15:23:45'       => '2003-02-10T15:23:45',
-    '1997-04-11T09:34'          => '1997-04-11T09:34:00',
-    '2002-05-12'                => '2002-05-12T00:00:00',
-    '1985-06'                   => '1985-06-01T00:00:00',
-    '1988'                      => '1988-01-01T00:00:00',
-    '2005-03-10T20:14:34+09:30' => '2005-03-10T10:44:34',
-    '2000-06-12T14:12:33Z'      => '2000-06-12T14:12:33',
-    '1994-11-05T08:15:30-05:00' => '1994-11-05T13:15:30',
+my $strict = $class->new(strict => 1);
+
+my @strict_tests = (
+    '2002-05-12'                   => '2002-05-12T00:00:00',
+    '1985-06'                      => '1985-06-01T00:00:00',
+    '1988'                         => '1988-01-01T00:00:00',
+    '2005-03-10T20:14:34+09:30'    => '2005-03-10T10:44:34',
+    '2000-06-12T14:12:33Z'         => '2000-06-12T14:12:33',
+    '1994-11-05T08:15:30-05:00'    => '1994-11-05T13:15:30',
     '2004-07-01T15:00:13.17-05:00' => '2004-07-01T20:00:13',
 );
+
+my @loose_tests = (
+    '2003-02-10T15:23:45' => '2003-02-10T15:23:45',
+    '1997-04-11T09:34'    => '1997-04-11T09:34:00',
+);
+
+my @tests = (@loose_tests, @strict_tests);
 
 while (@tests) {
     my ( $given, $expected ) = splice @tests, 0, 2;
     my $dt   = $class->parse_datetime($given)->set_time_zone('UTC');
     my $form = $dt->iso8601;
-    is( $form => $expected, "Parsing of $given => $expected." );
+    is( $form => $expected, "Loose parsing of $given => $expected." );
+}
+
+while (@strict_tests) {
+    my ( $given, $expected ) = splice @strict_tests, 0, 2;
+    my $dt   = $strict->parse_datetime($given)->set_time_zone('UTC');
+    my $form = $dt->iso8601;
+    is( $form => $expected, "Strict parsing of $given => $expected." );
 }
 
 my @noparse = (
@@ -41,5 +55,14 @@ my @noparse = (
 for (@noparse) {
     my $dt = eval { $class->parse_datetime($_) };
     ok( $@ && !( defined $dt && $dt->isa('DateTime') ),
-        "Correctly didn't parse '$_'" );
+        "Loose parsing failed: $_" );
 }
+
+push @noparse, @loose_tests[grep $_ % 2 == 0, 0..$#loose_tests];
+
+for (@noparse) {
+    my $dt = eval { $strict->parse_datetime($_) };
+    ok( $@ && !( defined $dt && $dt->isa('DateTime') ),
+        "Strict parsing failed: $_" );
+}
+

--- a/t/02bugs.t
+++ b/t/02bugs.t
@@ -11,7 +11,7 @@
 #   explicitly as "00:00:00", the method will not print a timestamp or an offset.
 
 use strict;
-use Test::More tests => 5;
+use Test::More tests => 7;
 
 use DateTime;
 use DateTime::Format::W3CDTF;
@@ -51,11 +51,29 @@ my @dates = (
         },
         w3cdtf => '2009-11-25T00:00:00+00:00',
         msg    => 'formatter handles tz offset of 0 properly'
+    }, {
+        date => {
+            year => 1977, month => 11, day => 11, hour => 1, minute => 12,
+            time_zone => 'floating'
+        },
+        w3cdtf => '1977-11-11T01:12:00',
+        msg    => 'loose formatter works with "floating" timezone',
+    }, {
+        date => {
+            year => 1977, month => 11, day => 11, hour => 1, minute => 12,
+            time_zone => 'floating'
+        },
+        strict => 1,
+        w3cdtf => undef,
+        msg    => 'strict formatter fails with "floating" timezone',
     }
 );
-my $f = DateTime::Format::W3CDTF->new();
 
 foreach my $d (@dates) {
-    my $dt = DateTime->new( %{ $d->{date} } );
-    is( $f->format_datetime($dt), $d->{w3cdtf}, $d->{msg} );
+    my %opts = map {$_ => $d->{$_}} qw/ strict default_tz /;
+    my $f    = DateTime::Format::W3CDTF->new(%opts);
+    my $dt   = DateTime->new( %{ $d->{date} } );
+    my $str  = eval { $f->format_datetime($dt) };
+
+    is( $str, $d->{w3cdtf}, $d->{msg} );
 }


### PR DESCRIPTION
The "strict" mode will more strictly follow W3CDTF standard and require all time components to have timezones.

So format_datetime() will die if given a "floating" DateTime (instead of returning a date string without timezone) and parse_datetime() will die if given a date string without timezone (instead of creating a "floating" DateTime).